### PR TITLE
Bring the file browser to a "somewhat working" state

### DIFF
--- a/middle/browserVFS.go
+++ b/middle/browserVFS.go
@@ -1,0 +1,70 @@
+package middle
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type BrowserLocation struct {
+	Location string
+	Dir      bool
+	Drive    string
+}
+
+const BrowserVFSPathDefault = "computer://"
+
+func BrowserVFSLocationReal(vfsPath string) bool {
+	return vfsPath != BrowserVFSPathDefault
+}
+
+func BrowserVFSList(vfsPath string) []BrowserLocation {
+	vfsEntries := []BrowserLocation{}
+
+	if vfsPath == BrowserVFSPathDefault {
+		if runtime.GOOS == "windows" {
+			for i := 0; i < 26; i++ {
+				drive := string(rune('A'+i)) + ":\\"
+				_, err := ioutil.ReadDir(drive)
+				if err == nil {
+					vfsEntries = append(vfsEntries, BrowserLocation{
+						Location: drive,
+						Dir:      true,
+						Drive:    drive,
+					})
+				}
+			}
+			return vfsEntries
+		}
+		home := os.Getenv("HOME")
+		return []BrowserLocation{
+			{
+				Drive:    "Home",
+				Location: home,
+				Dir:      true,
+			},
+			{
+				Drive:    "Root",
+				Location: "/",
+				Dir:      true,
+			},
+			{
+				Drive:    "PWD",
+				Location: ".",
+				Dir:      true,
+			},
+		}
+	}
+	fileInfos, err := ioutil.ReadDir(vfsPath)
+	if err == nil {
+		for _, fi := range fileInfos {
+			vfsEntries = append(vfsEntries, BrowserLocation{
+				Location: filepath.Join(vfsPath, fi.Name()),
+				Dir:      fi.IsDir(),
+			})
+		}
+	}
+
+	return vfsEntries
+}

--- a/middle/discord.go
+++ b/middle/discord.go
@@ -4,6 +4,7 @@ package middle
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 type DiscordInstance struct {
 	Path    string
 	Channel string
+	Valid   bool
 }
 
 func GetInstance(channel string) (DiscordInstance, error) {
@@ -34,6 +36,7 @@ func GetInstance(channel string) (DiscordInstance, error) {
 	instance := DiscordInstance{
 		Path:    "",
 		Channel: channel,
+		Valid:   false,
 	}
 
 	switch OS := runtime.GOOS; OS {
@@ -95,13 +98,31 @@ func NewDiscordInstance(path string) (*DiscordInstance, error) {
 	instance := DiscordInstance{
 		Path:    "",
 		Channel: "Unknown",
+		Valid:   false,
 	}
 
 	instance.Path = path
 
-	if _, err := os.Stat(instance.Path); err == nil {
+	if _, err := os.Stat(filepath.Join(instance.Path, "app.asar")); err == nil {
 		return &instance, nil
 	} else {
 		return &instance, errors.New("Instance doesn't exist")
 	}
 }
+
+func CheckDiscordLocation(dir string) *DiscordInstance {
+	if BrowserVFSLocationReal(dir) {
+		discordInstance, err := NewDiscordInstance(dir)
+		if err == nil {
+			fmt.Print("Discord instance found at " + dir + "\n")
+			if _, err := os.Stat(discordInstance.Path); err == nil {
+				discordInstance.Valid = true
+			}
+		}
+	}
+
+	return &DiscordInstance{
+		Path: dir,
+	}
+}
+

--- a/middle/discord.go
+++ b/middle/discord.go
@@ -13,9 +13,9 @@ import (
 )
 
 type DiscordInstance struct {
+	// Path to "resources" directory
 	Path    string
 	Channel string
-	Valid   bool
 }
 
 func GetInstance(channel string) (DiscordInstance, error) {
@@ -36,7 +36,6 @@ func GetInstance(channel string) (DiscordInstance, error) {
 	instance := DiscordInstance{
 		Path:    "",
 		Channel: channel,
-		Valid:   false,
 	}
 
 	switch OS := runtime.GOOS; OS {
@@ -96,17 +95,14 @@ func GetChannels() []DiscordInstance {
 
 func NewDiscordInstance(path string) (*DiscordInstance, error) {
 	instance := DiscordInstance{
-		Path:    "",
+		Path:    path,
 		Channel: "Unknown",
-		Valid:   false,
 	}
-
-	instance.Path = path
 
 	if _, err := os.Stat(filepath.Join(instance.Path, "app.asar")); err == nil {
 		return &instance, nil
 	} else {
-		return &instance, errors.New("Instance doesn't exist")
+		return nil, errors.New("Instance doesn't exist")
 	}
 }
 
@@ -115,14 +111,9 @@ func CheckDiscordLocation(dir string) *DiscordInstance {
 		discordInstance, err := NewDiscordInstance(dir)
 		if err == nil {
 			fmt.Print("Discord instance found at " + dir + "\n")
-			if _, err := os.Stat(discordInstance.Path); err == nil {
-				discordInstance.Valid = true
-			}
+			return discordInstance
 		}
 	}
-
-	return &DiscordInstance{
-		Path: dir,
-	}
+	return nil
 }
 

--- a/middle/discordFinderVFS.go
+++ b/middle/discordFinderVFS.go
@@ -1,15 +1,22 @@
 package middle
 
-func DiscordFinderVFSList(vfsPath string) []*DiscordInstance {
-	vfsEntries := []*DiscordInstance{}
+// A BrowserLocation with the output of CheckDiscordLocation.
+// The CCUpdaterUI code put the necessary information into GameInstance but Impregnate doesn't do that.
+// So we use this instead to get the same data.
+type FinderLocation struct {
+	BrowserLocation
+	Instance *DiscordInstance
+}
+
+func DiscordFinderVFSList(vfsPath string) []FinderLocation {
+	vfsEntries := []FinderLocation{}
 	for _, fi := range BrowserVFSList(vfsPath) {
 		if fi.Dir {
-			// cdl, err := NewDiscordInstance(fi.Location)
-			cdl := CheckDiscordLocation(fi.Location)
-			// if err == nil {
-			cdl.Path = fi.Location
-			vfsEntries = append(vfsEntries, cdl)
-			// }
+			finderLocation := FinderLocation {
+				BrowserLocation: fi,
+				Instance: CheckDiscordLocation(fi.Location),
+			}
+			vfsEntries = append(vfsEntries, finderLocation)
 		}
 	}
 	return vfsEntries

--- a/middle/discordFinderVFS.go
+++ b/middle/discordFinderVFS.go
@@ -1,0 +1,16 @@
+package middle
+
+func DiscordFinderVFSList(vfsPath string) []*DiscordInstance {
+	vfsEntries := []*DiscordInstance{}
+	for _, fi := range BrowserVFSList(vfsPath) {
+		if fi.Dir {
+			// cdl, err := NewDiscordInstance(fi.Location)
+			cdl := CheckDiscordLocation(fi.Location)
+			// if err == nil {
+			cdl.Path = fi.Location
+			vfsEntries = append(vfsEntries, cdl)
+			// }
+		}
+	}
+	return vfsEntries
+}

--- a/src/preface.go
+++ b/src/preface.go
@@ -92,6 +92,23 @@ func (app *UpApplication) ShowInstanceFinder(locations []middle.DiscordInstance)
 			{
 				Basis: design.SizeMarginAroundEverything,
 			},
+			{
+				Element: framework.NewUILabelPtr(integration.NewTextTypeChunk("If the installation you'd like to install Cumcord to isn't shown here, you can locate it manually.", design.GlobalFont), design.ThemeText, 0, frenyard.Alignment2i{}),
+			},
+			{
+				Basis: design.SizeMarginAroundEverything,
+			},
+			{
+				Element: design.ButtonBar([]framework.UILayoutElement{
+					design.ButtonAction(design.ThemeOkActionButton, "LOCATE MANUALLY", func() {
+						app.GSDownwards()
+						app.ShowDiscordFinder(func() {
+							app.GSUpwards()
+							app.ShowInstanceFinder(locations)
+						}, middle.BrowserVFSPathDefault)
+					}),
+				}),
+			},
 		},
 	})
 

--- a/src/showDiscordFinder.go
+++ b/src/showDiscordFinder.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (app *UpApplication) ShowDiscordFinder(back framework.ButtonBehavior, vfsPath string) {
-	var vfsList []*middle.DiscordInstance
+	var vfsList []middle.FinderLocation
 
 	app.ShowWaiter("Reading", func(progress func(string)) {
 		progress("Scanning to find all of the context in:\n" + vfsPath)
@@ -19,7 +19,7 @@ func (app *UpApplication) ShowDiscordFinder(back framework.ButtonBehavior, vfsPa
 		items := []design.ListItemDetails{}
 
 		for _, v := range vfsList {
-			thisLocation := v.Path
+			thisLocation := v.Location
 			ild := design.ListItemDetails{
 				Icon: design.DirectoryIconID,
 				Text: filepath.Base(thisLocation),
@@ -31,17 +31,17 @@ func (app *UpApplication) ShowDiscordFinder(back framework.ButtonBehavior, vfsPa
 					app.ShowDiscordFinder(back, vfsPath)
 				}, thisLocation)
 			}
-			if v.Valid {
+			if v.Instance != nil {
 				ild.Click = func() {
 					app.GSRightwards()
 					app.ResetWithDiscordInstance(true, thisLocation)
 				}
-				ild.Text = "Discord " + v.Channel
+				ild.Text = "Discord " + v.Instance.Channel
 				ild.Subtext = thisLocation
 				ild.Icon = design.GameIconID
-			} else if v.Path != "" {
-				ild.Text = v.Path
-				ild.Subtext = v.Path
+			} else if v.Drive != "" {
+				ild.Text = v.Drive
+				ild.Subtext = v.Location
 				ild.Icon = design.DriveIconID
 			}
 			items = append(items, ild)

--- a/src/showDiscordFinder.go
+++ b/src/showDiscordFinder.go
@@ -1,0 +1,57 @@
+package src
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/Cumcord/impregnate/middle"
+	"github.com/lexisother/frenyard/design"
+	"github.com/lexisother/frenyard/framework"
+)
+
+func (app *UpApplication) ShowDiscordFinder(back framework.ButtonBehavior, vfsPath string) {
+	var vfsList []*middle.DiscordInstance
+
+	app.ShowWaiter("Reading", func(progress func(string)) {
+		progress("Scanning to find all of the context in:\n" + vfsPath)
+		vfsList = middle.DiscordFinderVFSList(vfsPath)
+	}, func() {
+		items := []design.ListItemDetails{}
+
+		for _, v := range vfsList {
+			thisLocation := v.Path
+			ild := design.ListItemDetails{
+				Icon: design.DirectoryIconID,
+				Text: filepath.Base(thisLocation),
+			}
+			ild.Click = func() {
+				app.GSRightwards()
+				app.ShowDiscordFinder(func() {
+					app.GSLeftwards()
+					app.ShowDiscordFinder(back, vfsPath)
+				}, thisLocation)
+			}
+			if v.Valid {
+				ild.Click = func() {
+					app.GSRightwards()
+					app.ResetWithDiscordInstance(true, thisLocation)
+				}
+				ild.Text = "Discord " + v.Channel
+				ild.Subtext = thisLocation
+				ild.Icon = design.GameIconID
+			} else if v.Path != "" {
+				ild.Text = v.Path
+				ild.Subtext = v.Path
+				ild.Icon = design.DriveIconID
+			}
+			items = append(items, ild)
+		}
+
+		sort.Sort(design.SortListItemDetails(items))
+		primary := design.LayoutDocument(design.Header{
+			Back:  back,
+			Title: "Enter Discord's location",
+		}, design.NewUISearchBoxPtr("Directory name...", items), true)
+		app.Teleport(primary)
+	})
+}


### PR DESCRIPTION
It doesn't detect channels, and the limitation that it has to target the `resources` directory is annoying, but it should be possible to bring it the rest of the way now.